### PR TITLE
Upgrade log4j to 2.25.4 to fix security vulnerabilities

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -15,7 +15,7 @@
         <mvn.javase.version>1.8</mvn.javase.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <slf4j.version>1.7.36</slf4j.version>
-        <log4j.version>2.25.3</log4j.version>
+        <log4j.version>2.25.4</log4j.version>
         <disruptor.version>4.0.0</disruptor.version>
         <commons-lang.version>3.18.0</commons-lang.version>
         <commons-io.version>2.16.1</commons-io.version>


### PR DESCRIPTION
This PR upgrades the `log4j-core` dependency to version `2.25.4` by updating the `log4j.version` property in `core/pom.xml`. This version contains fixes for several moderate severity vulnerabilities: CVE-2026-34480, CVE-2026-34478, and CVE-2026-34477.

Testing performed:
- `mvn clean install -DskipTests` to verify build and dependency resolution.
- `mvn test` to ensure no regressions in the core module.
- Code review completed with #Correct# rating.

---
*PR created automatically by Jules for task [18343829806167324304](https://jules.google.com/task/18343829806167324304) started by @huayueh*